### PR TITLE
Extract the `dispose()` method from base classes

### DIFF
--- a/mother/src/main/java/uk/ac/uea/nostromo/mother/Disposable.java
+++ b/mother/src/main/java/uk/ac/uea/nostromo/mother/Disposable.java
@@ -1,0 +1,22 @@
+/*
+ * Disposable.java	v1.0.0	2015-11-29
+ */
+
+package uk.ac.uea.nostromo.mother;
+
+/**
+ * A {@code Disposable} object is an object that is able to release its
+ * internal resources once it has been told it is no long required.
+ *
+ * @author	Alex Melbourne {@literal <a.melbourne@uea.ac.uk>}
+ * @version	v1.0.0
+ * @since	!_TODO__ [Alex Melbourne] : Update this label before new release.
+ */
+public interface Disposable {
+	/**
+	 * Proceed to release any internally held resources.
+	 *
+	 * @since	!_TODO__ [Alex Melbourne] : Update this label before new release.
+	 */
+	void dispose();
+}

--- a/mother/src/main/java/uk/ac/uea/nostromo/mother/Image.java
+++ b/mother/src/main/java/uk/ac/uea/nostromo/mother/Image.java
@@ -6,11 +6,12 @@ import uk.ac.uea.nostromo.mother.Graphics.ImageFormat;
  * Simplistic image descriptor.
  *
  * @author	Unascribed
- * @version	v1.0.0
+ * @author	Alex Melbourne {@literal <a.melbourne@uea.ac.uk>}
+ * @version	v1.1.0
  * @since	!_TODO__ [Alex Melbourne <a.melbourne@uea.ac.uk>] : Update this label before new release.
  * @see		Graphics.ImageFormat
  */
-public interface Image {
+public interface Image extends Disposable {
 	/**
 	 * Get a pixel count representation of the width of the image.
 	 *
@@ -29,8 +30,4 @@ public interface Image {
 	 * @return	A value representing the bytewise format of the image.
 	 */
     public ImageFormat getFormat();
-	/**
-	 * Remove the underlying data being used to store the image.
-	 */
-    public void dispose();
 }

--- a/mother/src/main/java/uk/ac/uea/nostromo/mother/Music.java
+++ b/mother/src/main/java/uk/ac/uea/nostromo/mother/Music.java
@@ -5,12 +5,13 @@ package uk.ac.uea.nostromo.mother;
  * to be of some significant length, and paused/played as desired.
  *
  * @author	Unascribed
- * @version	v1.0.0
+ * @author	Alex Melbourne {@literal <a.melbourne@uea.ac.uk>}
+ * @version	v1.1.0
  * @since	!_TODO__ [Alex Melbourne <a.melbourne@uea.ac.uk>] : Update this label before new release.
  * @see		Audio
  * @see		Sound
  */
-public interface Music {
+public interface Music extends Disposable {
 	/**
 	 * Play the contained audio file.
 	 */
@@ -64,11 +65,6 @@ public interface Music {
 	 * @return	A boolean value indicating if the audio will loop.
 	 */
     public boolean isLooping();
-
-	/**
-	 * Remove the internal data storing this audio file.
-	 */
-    public void dispose();
 
 	/**
 	 * Move the playback marker to the beginning of the audio.

--- a/mother/src/main/java/uk/ac/uea/nostromo/mother/Sound.java
+++ b/mother/src/main/java/uk/ac/uea/nostromo/mother/Sound.java
@@ -5,12 +5,13 @@ package uk.ac.uea.nostromo.mother;
  * are short in length and designed to be played in full.
  *
  * @author	Unascribed
- * @version	v1.0.0
+ * @author	Alex Melbourne {@literal <a.melbourne@uea.ac.uk>}
+ * @version	v1.1.0
  * @since	!_TODO__ [Alex Melbourne <a.melbourne@uea.ac.uk>] : Update this label before new release.
  * @see		Audio
  * @see		Music
  */
-public interface Sound {
+public interface Sound extends Disposable {
 	/**
 	 * Play the stored sound file.
 	 *
@@ -18,9 +19,4 @@ public interface Sound {
 	 *					file should be played.
 	 */
     public void play(float volume);
-
-	/**
-	 * Remove the data representing the sound file from memory.
-	 */
-    public void dispose();
 }


### PR DESCRIPTION
Shift the declaration of the `dispose()` method from several base
classes into a separate interface.

Multiple instances of a piece of code allow for refactoring.